### PR TITLE
Fix indexing in partial_assignment.to_matrix()

### DIFF
--- a/qubolite/assignment.py
+++ b/qubolite/assignment.py
@@ -402,6 +402,7 @@ class partial_assignment:
         T = np.zeros((self.size, self.num_free+1))
         one = T.shape[1]-1 # index of constant 1
         j = 0
+        free_variable = np.zeros(self.size, dtype=int) # maps variable indices to free variable indices
         for i in range(self.size):
             u = f'x{i}'
             try:
@@ -409,13 +410,15 @@ class partial_assignment:
             except StopIteration:
                 # no outgoing edges -> free variable
                 T[i, j] = 1.0
+                free_variable[i] = j
                 j += 1
                 continue
             if v == '1':
                 if not data['inverse']:
                     T[i, one] = 1.0
             else:
-                l = int(v[1:])
+                l = free_variable[int(v[1:])]
+
                 if data['inverse']:
                     T[i, l] = -1.0
                     T[i, one] = 1.0


### PR DESCRIPTION
 #### Description
This PR fixes an indexing bug within the `partial_assignment.to_matrix()` function that causes an out-of-bounds `IndexError` or non-optimal variable assignments when preprocessing certain QUBO instances.

#### Context
In `partial_assignment.to_matrix()`, a transformation matrix `T` is constructed where:
* The first dimension corresponds to the original (old) variables.
* The second dimension corresponds to the new, free variables that were not fixed by the partial assignment.

**The Bug:** When populating `T` for equality or inequality assignments, the code erroneously used the index of the old variable for the second dimension, instead of mapping it to the index of the free variable. This leads to potential IndexErrors or non-optimal variable assignments as shown in the example below.

```python
import numpy as np
import qubolite as ql

A = np.array([[-70.,  99.,  24.,  56., -59., -88.,-27.],    
              [  0.,   3., -72., -23.,  11., -19., -68.],
              [  0.,   0.,  52., -83., -96.,  -8.,  -3.],
              [  0.,   0.,   0.,  89.,  71.,  83.,  65.],
              [  0.,   0.,   0.,   0.,  98., -36.,  97.],
              [  0.,   0.,   0.,   0.,   0.,  -7.,  -8.],
              [  0.,   0.,   0.,   0.,   0.,   0.,  -5.]])

Q = ql.qubo(A)
PA = ql.preprocessing.qpro_plus(Q)

# Fails here with IndexError on the main branch
Q_new, offset = PA.apply(Q)
```

#### Proposed Changes
In `partial_assignment.to_matrix()`, we construct a vector mapping old variable indices to their free variable indices and use it when constructing `T`.


